### PR TITLE
Escape Newline/Paragraph separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,9 @@ module.exports = function(source) {
 	this.cacheable && this.cacheable();
 	var value = typeof source === "string" ? JSON.parse(source) : source;
 	this.value = [value];
-	return "module.exports = " + JSON.stringify(value, undefined, "\t") + ";";
+	return "module.exports = " +
+			JSON.stringify(value, undefined, "\t")
+					.replace(/\u2028/g, '\\u2028')
+					.replace(/\u2029/g, '\\u2029') +
+			";";
 }


### PR DESCRIPTION
I think that the Webpack JSON loader seems like the right place to handle 
this issue.

For whatever reason, the JSON and Javascript specifications disagree on
whether or not strings can contain the unicode Newline or Paragraph 
characters.

In the case that a JSON object containing one of these characters is being
printed to a script tag, we should escape them.

See also, this discussion:
https://github.com/expressjs/express/issues/1132#issuecomment-10100419
